### PR TITLE
Terminate when encountering end of stream.

### DIFF
--- a/http2-client-grpc/Changelog.md
+++ b/http2-client-grpc/Changelog.md
@@ -4,6 +4,9 @@
 
 - Support connecting to unix sockets and already connected sockets. [#44](https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/44)
 - Make `waitReply` not rely on the background thread. Decreases latency of `rawUnary` and related queries..
+- Fix a bug where a streaming call which failed immediately would lead to a
+  hanging request.
+
 
 ## 0.8.0.0
 

--- a/http2-client-grpc/src/Network/GRPC/Client.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client.hs
@@ -241,7 +241,7 @@ streamReply rpc v0 req handler = RPCCall rpc $ \conn stream isfc osfc encoding d
         _waitEvent stream >>= \case
             StreamHeadersEvent frHeaders hdrs ->
                    -- In case the response is an immediate error, there will typically
-                   -- not be any additional data, so we cannot ender the loop above,
+                   -- not be any additional data, so we cannot enter the loop above,
                    -- since that will not receive any additional events. So we terminate early.
                    if testEndStream (flags frHeaders) then
                      -- In this scenario there are only trailers, we only received that frame.


### PR DESCRIPTION
## Purpose

When receiving END_STREAM terminate processing. Handle this even if we receive this just after receiving initial headers/trailers.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

